### PR TITLE
Add aliases to readme

### DIFF
--- a/README.org
+++ b/README.org
@@ -41,9 +41,11 @@ To use *find-deps* from the command line, create an alias in your
 ~/.clojure/deps.edn map:
 
 #+BEGIN_SRC clojure
-:find-deps {:extra-deps {find-deps {:git/url "https://github.com/hagmonk/find-deps"
-                                    :sha     "682525ee1874f186668bfb3884c72e0252d77771"}}
-            :main-opts  ["-m" "find-deps.core"]}
+{:aliases {:find-deps {:extra-deps
+                         {find-deps
+                            {:git/url "https://github.com/hagmonk/find-deps",
+                             :sha "682525ee1874f186668bfb3884c72e0252d77771"}},
+                       :main-opts ["-m" "find-deps.core"]}}}
 #+END_SRC
 
 You can invoke *find-deps* with ~-h~ to see the supported options:


### PR DESCRIPTION
The lack of an `aliases` key in the deps.edn sample was confusing to me, and I couldn't figure out why it wasn't working. This adds the key explicitly.