### PR TITLE
docs: add missing deps to readme

### DIFF
--- a/README.org
+++ b/README.org
@@ -47,10 +47,12 @@ To use *find-deps* from the command line, create an alias in your
 
 #+BEGIN_SRC clojure
 {:aliases {:find-deps {:extra-deps
-                         {find-deps
-                            {:git/url "https://github.com/hagmonk/find-deps",
-                             :sha "6fc73813aafdd2288260abb2160ce0d4cdbac8be"}},
-                       :main-opts ["-m" "find-deps.core"]}}}
+   {org.clojure/core.async {:mvn/version "1.1.587"},
+    cheshire {:mvn/version "5.10.0"},
+    find-deps
+    {:git/url "https://github.com/hagmonk/find-deps",
+     :sha "6fc73813aafdd2288260abb2160ce0d4cdbac8be"}},
+   :main-opts ["-m" "find-deps.core"]}}}
 #+END_SRC
 
 You can invoke *find-deps* with ~-h~ to see the supported options:


### PR DESCRIPTION
Adds missing deps to readme quick-start suggestion.

Could see you wanting to leave this out, but I thought I'd throw up the
PR just to document it. Without these, the result is a giant stacktrace
in the shell, and I figured people would rather have them there if they
were copy-pasting into deps.edn anyway.